### PR TITLE
Adds coordinate scaling to fix max-width issue.

### DIFF
--- a/jquery.rwdImageMaps.js
+++ b/jquery.rwdImageMaps.js
@@ -1,0 +1,67 @@
+/*
+* rwdImageMaps jQuery plugin v1.5
+*
+* Allows image maps to be used in a responsive design by recalculating the area coordinates to match the actual image size on load and window.resize
+*
+* Copyright (c) 2013 Matt Stow
+* https://github.com/stowball/jQuery-rwdImageMaps
+* http://mattstow.com
+* Licensed under the MIT license
+*/
+;(function($) {
+	$.fn.rwdImageMaps = function() {
+		var $img = this;
+		
+		var rwdImageMap = function() {
+			$img.each(function() {
+				if (typeof($(this).attr('usemap')) == 'undefined')
+					return;
+				
+				var that = this,
+					$that = $(that);
+				
+				// Since WebKit doesn't know the height until after the image has loaded, perform everything in an onload copy
+				$('<img />').load(function() {
+					var attrW = 'width',
+						attrH = 'height',
+						w = $that.attr(attrW),
+						h = $that.attr(attrH);
+					
+					if (!w || !h) {
+						var temp = new Image();
+						temp.src = $that.attr('src');
+						if (!w)
+							w = temp.width;
+						if (!h)
+							h = temp.height;
+					}
+					
+					var wPercent = $that.width()/100,
+						hPercent = $that.height()/100,
+						map = $that.attr('usemap').replace('#', ''),
+						c = 'coords';
+					
+					$('map[name="' + map + '"]').find('area').each(function() {
+						var $this = $(this);
+						if (!$this.data(c))
+							$this.data(c, $this.attr(c));
+						
+						var coords = $this.data(c).split(','),
+							coordsPercent = new Array(coords.length);
+						
+						for (var i = 0; i < coordsPercent.length; ++i) {
+							if (i % 2 === 0)
+								coordsPercent[i] = parseInt(((coords[i]/w)*100)*wPercent);
+							else
+								coordsPercent[i] = parseInt(((coords[i]/h)*100)*hPercent);
+						}
+						$this.attr(c, coordsPercent.toString());
+					});
+				}).attr('src', $that.attr('src'));
+			});
+		};
+		$(window).resize(rwdImageMap).trigger('resize');
+		
+		return this;
+	};
+})(jQuery);

--- a/script.js
+++ b/script.js
@@ -1,0 +1,5 @@
+/* DOKUWIKI:include_once jquery.rwdImageMaps.js */
+
+jQuery(document).ready(function(e) {
+    jQuery('img.imap').rwdImageMaps();
+});


### PR DESCRIPTION
When using large images the current DokuWiki default template automatically scales the image to `max-width: 100%`. Unfortunately, this makes large image maps unusable because the clickable areas aren't scaled together with the image.

This can be fixed by scaling the image map itself as well. This fix is based on @stowball's https://github.com/stowball/jQuery-rwdImageMaps.
