### PR TITLE
give an "id" attribute (beside the "name") in the <map> tab

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -121,7 +121,7 @@ class syntax_plugin_imagemap extends DokuWiki_Syntax_Plugin {
             $renderer->doc .= ' height="'.$renderer->_xmlEntities($height).'"';
         $renderer->doc .= ' />'.DOKU_LF;
         $renderer->doc .= '</p>'.DOKU_LF;
-        $renderer->doc .= '<map name="'.$name.'">'.DOKU_LF;
+        $renderer->doc .= '<map name="'.$name.'" id="'.$name.'">'.DOKU_LF;
         $has_content = false;
         break;
       case DOKU_LEXER_MATCHED:


### PR DESCRIPTION
some browsers (Chrome, FF, Opera) in some versions require that ( see http://stackoverflow.com/questions/5527290/image-map-support-in-firefox-chrome-and-other-browsers , http://stackoverflow.com/questions/11156054/image-map-not-referenceable-by-id  etc...)
