### PR TITLE
Detritus compatibility

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -16,7 +16,7 @@ require_once(DOKU_PLUGIN.'syntax.php');
 
 class syntax_plugin_imagemap extends DokuWiki_Syntax_Plugin {
 
-    function syntax_plugin_imagemap() {
+    function __construct() {
     }
 
     function getInfo(){
@@ -228,7 +228,7 @@ class syntax_plugin_imagemap extends DokuWiki_Syntax_Plugin {
 
 }
 
-class ImageMap_Handler {
+class ImageMap_Handler implements Doku_Handler_CallWriter_Interface {
 
     var $CallWriter;
 
@@ -236,7 +236,7 @@ class ImageMap_Handler {
     var $areas = array();
     var $mapname;
 
-    function ImageMap_Handler($name, &$CallWriter) {
+    function __construct($name, &$CallWriter) {
         $this->CallWriter =& $CallWriter;
         $this->mapname = $name;
     }


### PR DESCRIPTION
    Catchable fatal error: Argument 1 passed to Doku_Handler_List::__construct() must implement interface Doku_Handler_CallWriter_Interface, instance of ImageMap_Handler given, called in /www/wiki/inc/parser/handler.php on line 235 and defined in /www/wiki/inc/parser/handler.php on line 827

- ImageMap_Handler implements Doku_Handler_CallWriter_Interface for Detritus compatibility
- replace PHP 4 style constructors